### PR TITLE
Question and Answer | Possible fix for mid sentence death

### DIFF
--- a/lua/autorun/lambda-conversation-module.lua
+++ b/lua/autorun/lambda-conversation-module.lua
@@ -100,9 +100,9 @@ local function Initialize( self, wepent )
 
         -- Not answering a question, therefor we must ask one.
         -- Small chance that we ask a new one.
-        if !self.lc_respondent or random( 100 ) <= 5 then
+        if !self.lc_respondent or random( 100 ) <= 1 then
             self:PlaySoundFile( GetConVar( "lambdaplayers_voice_conquestiondir" ):GetString() == "randomengine" and self:GetRandomSound() or self:GetVoiceLine( "conquestion" ), true )
-            
+
             self.lc_respondent = true -- We set ourself as a respondent to avoid making us the only inquirer in a one on one convo
             for k, v in ipairs( self.lc_group ) do
                 v.lc_respondent = true -- Asked a question, the rest must answer.
@@ -111,7 +111,7 @@ local function Initialize( self, wepent )
         -- We are answering a question
         else
             self:PlaySoundFile( GetConVar( "lambdaplayers_voice_conresponddir" ):GetString() == "randomengine" and self:GetRandomSound() or self:GetVoiceLine( "conrespond" ), true )
-
+            
             self.lc_respondent = false -- Provided a response to the question. If we go back to us, we will ask a question.
         end
         
@@ -258,8 +258,8 @@ end
 
 local function RegisterConVoices()
 
-    LambdaRegisterVoiceType( "conquestion", "lambdaplayers/vo/conquestion", "These are voice lines that play when a Lambda Player asks a question in a conversation." )
-    LambdaRegisterVoiceType( "conrespond", "lambdaplayers/vo/conrespond", "These are voice lines that play when a Lambda Player answer in a conversation." )
+    LambdaRegisterVoiceType( "conquestion", "randomengine", "These are voice lines that play when a Lambda Player asks a question in a conversation." )
+    LambdaRegisterVoiceType( "conrespond", "randomengine", "These are voice lines that play when a Lambda Player answer in a conversation." )
 
 end
 

--- a/lua/autorun/lambda-conversation-module.lua
+++ b/lua/autorun/lambda-conversation-module.lua
@@ -214,7 +214,7 @@ end
 
 local function OnRemove( self )
     local partner = self.lc_group[ random( #self.lc_group ) ]
-    if IsValid( partner ) and self.lc_canspeak then partner.lc_canspeak = true end
+    if IsValid( partner ) and (self:IsSpeaking() or self.lc_canspeak) then partner.lc_canspeak = true end
     
     for k, v in ipairs( self.lc_group ) do
         if !v.lc_group then continue end

--- a/lua/autorun/lambda-conversation-module.lua
+++ b/lua/autorun/lambda-conversation-module.lua
@@ -98,16 +98,21 @@ local function Initialize( self, wepent )
         
         hook.Run( "LambdaConvoOnSpeak", self )
 
-        if !self.lc_respondent then -- Not answering a question, therefor we must ask one.
+        -- Not answering a question, therefor we must ask one.
+        -- Small chance that we ask a new one.
+        if !self.lc_respondent or random( 100 ) <= 5 then
             self:PlaySoundFile( GetConVar( "lambdaplayers_voice_conquestiondir" ):GetString() == "randomengine" and self:GetRandomSound() or self:GetVoiceLine( "conquestion" ), true )
-            print("CONV DEBUG:", self:GetLambdaName() ,"asked question")
+            
+            self.lc_respondent = true -- We set ourself as a respondent to avoid making us the only inquirer in a one on one convo
             for k, v in ipairs( self.lc_group ) do
                 v.lc_respondent = true -- Asked a question, the rest must answer.
             end
-        else -- We are answering a question
+
+        -- We are answering a question
+        else
             self:PlaySoundFile( GetConVar( "lambdaplayers_voice_conresponddir" ):GetString() == "randomengine" and self:GetRandomSound() or self:GetVoiceLine( "conrespond" ), true )
-            self.lc_respondent = false -- Provided a response to the question.
-            print("CONV DEBUG:", self:GetLambdaName() ,"answered")
+
+            self.lc_respondent = false -- Provided a response to the question. If we go back to us, we will ask a question.
         end
         
         self.lc_canspeak = false


### PR DESCRIPTION
#### Adds a very simple question / answer
The first lambda that talks asks a question, everyone in the conversation group gets set to "going to answer".
The one that ask a question also gets set a "going to answer", to avoid one on one's to be _one_ sided

Everytime it randomly land on a Lambda, checks if they need to answer and do so.
They have 1% chance of not answering and asking a new question, just to add some randomness.

#### Possible fix for mid sentence death
Adds a check for if the Lambda IsSpeaking when killed or removed and gives the lc_canspeak to someone else.
From my testing, seems to work but it makes whoever gets it speak instantly.

#### Also a small random in the lookat to make them a tiny bit less snappy.